### PR TITLE
Fix decoding of QueryExecuter response

### DIFF
--- a/src/QueryExecuter.php
+++ b/src/QueryExecuter.php
@@ -65,7 +65,7 @@ class QueryExecuter {
 		}
 
 		$result = $this->getResult( $query );
-		return $result['search'];
+		return $result['results'];
 	}
 
 	private function getResult( $query ) {

--- a/tests/unit/QueryExecuterTest.php
+++ b/tests/unit/QueryExecuterTest.php
@@ -24,7 +24,7 @@ class QueryExecuterTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( 'test.example.com' ),
 				$this->equalTo( $params )
 			)
-			->will( $this->returnValue( '{"search":"~=[,,_,,]:3"}' ) );
+			->will( $this->returnValue( '{"results":"~=[,,_,,]:3"}' ) );
 
 		return $http;
 	}


### PR DESCRIPTION
The code used to for me but seems something perhaps changed in the query json response format.

https://www.w3.org/TR/rdf-sparql-json-res/ is the format, per https://wiki.blazegraph.com/wiki/index.php/REST_API

Changing the $result array key used to 'results' makes QueryExecuter work as expected.

My query is https://phabricator.wikimedia.org/P2501 and results are https://phabricator.wikimedia.org/P2500
